### PR TITLE
Optional cache for diff results 

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,24 @@
+var benchmark = require('async-benchmark')
+  , concat = require('concat-stream')
+  , test = require('tape')
+  , createStream = require('./significant-stream')
+  , runTest = function (input, options, done) {
+      var stream = createStream(options)
+      stream.pipe(concat({ encoding: 'object' }, done))
+      input.forEach(function (data) { stream.write(data) })
+      stream.end()
+    }
+  , inputs = [
+      Array(500).join('A'),
+      Array(500).join('B') + Array(100).join('C'),
+      Array(500).join('B') + Array(100).join('C') + 'beep boop',
+    ]
+  , benchCache = function (done) { runTest(inputs, { cache: { max: 500 } }, done) }
+  , benchNoCache = function (done) { runTest(inputs, {}, done) }
+
+benchmark('SignificantStream with cache', benchCache, function (err, event) {
+  console.log(event.target.toString())
+  benchmark('SignificantStream no cache', benchNoCache, function (err, event) {
+    console.log(event.target.toString())
+  })
+})

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -2,67 +2,79 @@ var DiffMatchPatch = require('diff-match-patch')
 
   , diffMatchPatch = new DiffMatchPatch()
 
-  , diffStats = function (before, after) {
-      var stats = { inserts: false, deletes: false }
-        , diff = diffMatchPatch.diff_main(before, after)
-        , index
-
-      for(index = 0; index < diff.length; ++index) {
-        if (diff[index][0] === -1) stats.deletes = true
-        if (diff[index][0] === 1) stats.inserts = true
-        if (stats.deletes && stats.inserts) break
-      }
-      return stats
-    }
-
-  , mergeInserts = function (input, getData) {
-      if (input.length < 2) return input.slice(0)
-
-      var index
-        , results = [ input.pop() ]
-        , stats
-
-      for(index = input.length - 1; index >= 0;  index--) {
-        stats = diffStats(
-            getData(input[index])
-          , getData(results[0])
-        )
-
-        if (stats.deletes) {
-          results.unshift(input[index])
-        }
-      }
-
-      return results
-    }
-
-  , mergeDeletes = function (input, getData) {
-      if (input.length < 2) return input.slice(0)
-
-      var index
-        , results = [ input.shift() ]
-        , stats
-
-      for(index = 0; index < input.length - 1; ++index) {
-        stats = diffStats(
-            getData(results[results.length - 1])
-          , getData(input[index])
-        )
-
-        if (stats.inserts) {
-          results.push(input[index])
-        }
-      }
-      // always include the last revision
-      results.push(input[input.length - 1])
-
-      return results
-    }
-
   , createMerge = function (options) {
-
-      var getData = options && options.key ?
+      var cache = options.cache && require('lru-cache')(options.cache)
+        , getData = options && options.key ?
             function (obj) { return obj[options.key]} : function (obj) { return obj }
+
+        , diffStats = function (before, after) {
+            var cacheKey = before + after;
+            if (options.cache) {
+              var cachedResponse = cache.get(cacheKey);
+              if (cachedResponse) {
+                return cachedResponse;
+              }
+            }
+
+            var stats = { inserts: false, deletes: false }
+              , diff = diffMatchPatch.diff_main(before, after)
+              , index
+
+            for(index = 0; index < diff.length; ++index) {
+              if (diff[index][0] === -1) stats.deletes = true
+              if (diff[index][0] === 1) stats.inserts = true
+              if (stats.deletes && stats.inserts) break
+            }
+
+            if (options.cache) {
+              cache.set(cacheKey, stats);
+            }
+            return stats
+          }
+
+      , mergeInserts = function (input, getData) {
+          if (input.length < 2) return input.slice(0)
+
+          var index
+            , results = [ input.pop() ]
+            , stats
+
+          for(index = input.length - 1; index >= 0;  index--) {
+            stats = diffStats(
+                getData(input[index])
+              , getData(results[0])
+            )
+
+            if (stats.deletes) {
+              results.unshift(input[index])
+            }
+          }
+
+          return results
+        }
+
+      , mergeDeletes = function (input, getData) {
+          if (input.length < 2) return input.slice(0)
+
+          var index
+            , results = [ input.shift() ]
+            , stats
+
+          for(index = 0; index < input.length - 1; ++index) {
+            stats = diffStats(
+                getData(results[results.length - 1])
+              , getData(input[index])
+            )
+
+            if (stats.inserts) {
+              results.push(input[index])
+            }
+          }
+          // always include the last revision
+          results.push(input[input.length - 1])
+
+          return results
+        }
 
       return function (input) {
         return mergeDeletes(mergeInserts(input, getData), getData)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "significant-stream.js",
   "dependencies": {
     "diff-match-patch": "^1.0.0",
+    "lru-cache": "^4.1.1",
     "through2": "^0.6.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "through2": "^0.6.3"
   },
   "devDependencies": {
+    "async-benchmark": "^1.0.1",
     "concat-stream": "^1.4.6",
     "tape": "^3.0.1"
   },

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ npm install significant-stream
 ```javascript
 var stream1 = require('./significant-stream')()
   , stream2 = require('./significant-stream')({ key: 'foo' })
+  , stream3 = require('./significant-stream')({ cache: { max: 100 } }) // LRU cache options
 
 stream1.on('data', function (row) { console.log('data from stream1', row) })
 
@@ -32,6 +33,14 @@ stream2.on('data', function (obj) { console.log('data from stream2', obj) })
 stream2.write({ foo: 'Yeah', bar: 'beep' })
 stream2.write({ foo: 'Oh, Yeah', bar: 'boop' })
 stream2.end()
+
+console.log('stream3 has same behaviour as stream1, but uses lru-cache for diff')
+stream1.on('data', function (row) { console.log('data from stream3', row) })
+stream1.write('Hello')
+stream1.write('Hello, world!')
+stream1.end()
+
+
 ```
 
 ### Output
@@ -41,6 +50,8 @@ stream1 will only ouput the second string, since the diff between them is an app
 data from stream1 Hello, world!
 stream2 has similar behaviour as stream1, but it is an object
 data from stream2 { foo: 'Oh, Yeah', bar: 'boop' }
+stream3 has same behaviour as stream1, but uses lru-cache for diff
+data from stream3 Hello, world!
 ```
 
 ## Licence

--- a/significant-stream.js
+++ b/significant-stream.js
@@ -3,7 +3,7 @@ var createMerge = require('./lib/merge')
   , through = require('through2')
 
   , createSignificantStream = function (options) {
-      var merge = createMerge(options)
+      var merge = createMerge(options || {})
         , buffer = []
         , write = function (obj, _, callback) {
             buffer.push(obj)

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 var concat = require('concat-stream')
   , test = require('tape')
- 
+
   , createStream = require('./significant-stream')
 
   , runTest = function (input, callback) {
@@ -135,6 +135,19 @@ test('lots of inputs', function (t) {
 test('object as input', function (t) {
   var input = [ { data: 'hej' }, { data: 'hejhopp' } ]
     , stream = createStream({ key: 'data' })
+
+  stream.pipe(concat({ encoding: 'object' }, function (array) {
+    t.deepEqual(array, [ input[1] ])
+    t.end()
+  }))
+
+  input.forEach(function (row) { stream.write(row) })
+  stream.end()
+})
+
+test('with cache', function (t) {
+  var input = [ 'beep', 'beep boop' ]
+    , stream = createStream({ cache: { max: 500 } })
 
   stream.pipe(concat({ encoding: 'object' }, function (array) {
     t.deepEqual(array, [ input[1] ])


### PR DESCRIPTION
For certain inputs the diff calculation was taking a long time, for our use case this was causing the request to timeout. I played around with different possible solutions and found that caching the diff results had a great impact on performance. However, while trying to benchmark this I found that the cache is not always good for performance (or just not making a huge difference), because of that I made the cache optional so it's possible to set/tweak for different use cases. 

This is the output from benchmark.js when I run it locally: 
<img width="495" alt="screen shot 2018-02-26 at 11 44 10 am" src="https://user-images.githubusercontent.com/1212640/36666787-fae1bfe6-1aeb-11e8-8294-38963d53d1cc.png">
